### PR TITLE
Update buffer size

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -1,7 +1,9 @@
 publishTo := {
   val defaultDestination = publishTo.value
   if (isSnapshot.value) {
-    Some("Scalefactor Snapshots" at "s3://s3-us-west-2.amazonaws.com/scalefactor-libraries/snapshots")
+    Some(
+      "Scalefactor Snapshots" at "s3://s3-us-west-2.amazonaws.com/scalefactor-libraries/snapshots"
+    )
   } else {
     Some("Scalefactor Releases" at "s3://s3-us-west-2.amazonaws.com/scalefactor-libraries/releases")
   }
@@ -17,4 +19,4 @@ pomIncludeRepository := { _ =>
 } //remove optional dependencies from our pom
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-publishMavenStyle := true 
+publishMavenStyle := true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -436,6 +436,10 @@ kinesis {
          # It is strongly recommended that this is larger than the batch timeout * retries
          # This will help prevent message duplication due to unfinished batches on shutdown
          shutdownTimeoutSeconds = 25
+
+         # We need this number to calculate the buffer size for the kinesis source. Since we don't have the kinesis connection
+         # in scope we'll pass it in as a var for now
+         expectedNumberOfShards = 1
       }
 
       checkpointer {

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -60,14 +60,16 @@ object ConsumerWorker {
       *         failureTolerancePercentage = 0.25
       *         shutdownTimeoutSeconds = 5
       *         gracefulShutdownHook = true
+                expectedNumberOfShards = 1
       *      }
       * }}}
       */
     def apply(consumerConfig: Config): ConsumerWorkerConf = {
-      val shutdownHook         = consumerConfig.getBoolean("worker.gracefulShutdownHook")
-      val shutdownTimeout      = consumerConfig.getInt("worker.shutdownTimeoutSeconds").seconds
-      val batchTimeout         = consumerConfig.getInt("worker.batchTimeoutSeconds").seconds
-      val failedMessageRetries = consumerConfig.getInt("worker.failedMessageRetries")
+      val shutdownHook           = consumerConfig.getBoolean("worker.gracefulShutdownHook")
+      val shutdownTimeout        = consumerConfig.getInt("worker.shutdownTimeoutSeconds").seconds
+      val batchTimeout           = consumerConfig.getInt("worker.batchTimeoutSeconds").seconds
+      val failedMessageRetries   = consumerConfig.getInt("worker.failedMessageRetries")
+      val expectedNumberOfShards = consumerConfig.getInt("worker.expectedNumberOfShards")
       val failureTolerancePercentage =
         consumerConfig.getDouble("worker.failureTolerancePercentage")
 
@@ -75,7 +77,8 @@ object ConsumerWorker {
                              failedMessageRetries,
                              failureTolerancePercentage,
                              shutdownHook,
-                             Timeout(shutdownTimeout))
+                             Timeout(shutdownTimeout),
+                             expectedNumberOfShards)
     }
   }
 
@@ -93,7 +96,8 @@ object ConsumerWorker {
                                       failedMessageRetries: Int,
                                       failureTolerancePercentage: Double,
                                       shutdownHook: Boolean,
-                                      shutdownTimeout: Timeout)
+                                      shutdownTimeout: Timeout,
+                                      expectedNumberOfShards: Int)
 
   //TODO should these messages (sent to/from the processor) live in the models package?
   /**

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStage.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStage.scala
@@ -149,7 +149,7 @@ class KinesisSourceGraphStage(config: ConsumerConf,
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
       // KCL will read events in batches. The stream should be able to buffer the whole batch.
-      private[this] val bufferSize: Int = config.kclConfiguration.getMaxRecords
+      private[this] val bufferSize: Int = config.kclConfiguration.getMaxRecords * 20
       // The queue to buffer events that can not be pushed downstream.
       private[this] val messages = new java.util.ArrayDeque[CommittableEvent[ConsumerEvent]]()
       // The kinesis consumer to read from.

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStage.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStage.scala
@@ -149,7 +149,8 @@ class KinesisSourceGraphStage(config: ConsumerConf,
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
       // KCL will read events in batches. The stream should be able to buffer the whole batch.
-      private[this] val bufferSize: Int = config.kclConfiguration.getMaxRecords * 20
+      private[this] val bufferSize
+        : Int = config.kclConfiguration.getMaxRecords * config.workerConf.expectedNumberOfShards
       // The queue to buffer events that can not be pushed downstream.
       private[this] val messages = new java.util.ArrayDeque[CommittableEvent[ConsumerEvent]]()
       // The kinesis consumer to read from.

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
@@ -89,7 +89,8 @@ class ConsumerWorkerSpec
                                batchRetries,
                                failureTolerance,
                                false,
-                               shutdownTimeout),
+                               shutdownTimeout,
+                               1),
             Props(new ChildForwarder(checkpointerProbe.ref))
           )
         )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.12-SNAPSHOT"
+version in ThisBuild := "0.6.13-SNAPSHOT"


### PR DESCRIPTION
We need to increase the buffer size for the Kinesis source because we read from more than one shard and if theres a slow down we don't want it to fill up.